### PR TITLE
Restore options for compatiblity with internally built Google pods

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 nanopb doesn't follow https://semver.org/, so we'll use the following scheme:
 
 nanopb version `a.b.c` becomes `a.b.(c*100)` and nanopb version `a.b.c.d`
-becomes `a.b.(c*100+d)`
+becomes `a.b.(c*10000+d*100+e)` where e is the version of the podspec.
 
-Example: nanopb 0.3.9 => 0.3.900, and nanopb 0.3.9.1 => 0.3.901
+Example: nanopb 0.3.9 => 0.3.90000, and nanopb 0.3.9.1 => 0.3.90100 and a
+podspec only rev would be 0.3.90101.

--- a/nanopb/0.3.9.1/nanopb.podspec
+++ b/nanopb/0.3.9.1/nanopb.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "nanopb"
-  s.version      = "0.3.901"
+  s.version      = "0.3.90101"
   s.summary      = "Protocol buffers with small code size."
 
   s.description  = <<-DESC
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/nanopb/nanopb.git", :tag => "0.3.9.1" }
 
   s.requires_arc = false
-  s.xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) PB_FIELD_32BIT=1 PB_NO_PACKED_STRUCTS=1 PB_ENABLE_MALLOC=1' }
+  s.xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) PB_FIELD_32BIT=1 PB_NO_PACKED_STRUCTS=1' }
 
   s.source_files  = '*.{h,c}'
   s.public_header_files  = '*.h'


### PR DESCRIPTION
Restore options so that CocoaPods libraries that depend on nanopb are interoperable with Google internally built libraries.

I could use some help with testing since I don't know the reason that PB_ENABLE_MALLOC was added.
