### PR TITLE
Rollback nanopb to 0.3.9.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 nanopb doesn't follow https://semver.org/, so we'll use the following scheme:
 
-nanopb version `a.b.c` becomes `a.b.(c*100)` and nanopb version `a.b.c.d`
-becomes `a.b.(c*100+d)`
+nanopb version `a.b.c` becomes `a.b.(c*1000)` and nanopb version `a.b.c.d`
+becomes `a.b.(c*1000+d*10+podspec_revision)`
 
-Example: nanopb 0.3.9 => 0.3.900, and nanopb 0.3.9.1 => 0.3.901
+Example: nanopb 0.3.9 => 0.3.9000, and nanopb 0.3.9.1 => 0.3.9010
+
+Converted to four digit version after upgrade from 0.3.9.1 to 0.3.9.4 failed
+and required a rollback.

--- a/nanopb.podspec
+++ b/nanopb.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "nanopb"
-  s.version      = "0.3.904"
+  s.version      = "0.3.9011"
   s.summary      = "Protocol buffers with small code size."
 
   s.description  = <<-DESC
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/nanopb/nanopb"
   s.license      = { :type => 'zlib', :file => 'LICENSE.txt' }
   s.author       = { "Petteri Aimonen" => "jpa@nanopb.mail.kapsi.fi" }
-  s.source       = { :git => "https://github.com/nanopb/nanopb.git", :tag => "0.3.9.4" }
+  s.source       = { :git => "https://github.com/nanopb/nanopb.git", :tag => "0.3.9.1" }
 
   s.requires_arc = false
   s.xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) PB_FIELD_32BIT=1 PB_NO_PACKED_STRUCTS=1 PB_ENABLE_MALLOC=1' }


### PR DESCRIPTION
Roll forward to rollback to address https://github.com/firebase/firebase-ios-sdk/issues/4154 with Analytics Objective C wrapper around 0.3.9.4

This PR also adjusts the semver conversion scheme to enable podspec only revisions.