### PR TITLE
New CocoaPods versioning scheme and update to 0.3.9.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 ### Version numbers
 
-Starting with nanopb 0.3.9.4, the CocoaPods version is disconnected from the
+Starting with nanopb 0.3.9.5, the CocoaPods version is disconnected from the
 nanopb version and is described by the following table:
 
 | CocoaPods Version | nanopb version |
 | ----------------- | -------------- |
-| 1.0.0             | 0.3.9.4        |
+| 1.0.0             | 0.3.9.5        |
 
 
 #### Version rationale and background

--- a/README.md
+++ b/README.md
@@ -1,10 +1,24 @@
 ### Version numbers
 
-nanopb doesn't follow https://semver.org/, so we'll use the following scheme:
-
 Starting with nanopb 0.3.9.4, the CocoaPods version is disconnected from the
 nanopb version and is described by the following table:
 
 | CocoaPods Version | nanopb version |
 | ----------------- | -------------- |
 | 1.0.0             | 0.3.9.4        |
+
+
+#### Version rationale and background
+
+nanopb doesn't follow https://semver.org/. It uses four digit versions and is
+still setting the major version to 0 which in semver implies any update can be
+breaking.
+
+While nanopb tries to follow a variation of semver and updates the fourth digit
+for non-breaking patch updates, the policy is not enforced for binary
+dependencies which can break when source dependencies don't, like the `#define`
+changes in 0.3.9.4.
+
+The versioning scheme is exacerbated by early Firebase releases specifying
+CocoaPods dependencies with `"nanopb": "~> 0.3"` which allows an update to any
+subsequent 0.* release.

--- a/README.md
+++ b/README.md
@@ -1,24 +1,23 @@
 ### Version numbers
 
-Starting with nanopb 0.3.9.5, the CocoaPods version is disconnected from the
-nanopb version and is described by the following table:
-
-| CocoaPods Version | nanopb version |
-| ----------------- | -------------- |
-| 1.0.0             | 0.3.9.5        |
-
-
-#### Version rationale and background
-
-nanopb doesn't follow https://semver.org/. It uses four digit versions and is
-still setting the major version to 0 which in semver implies any update can be
+nanopb doesn't follow https://semver.org/. It uses four digit versions and has
+only used major version 0 which in semver implies any update can be
 breaking.
+
+The CocoaPods minor version is calculated from the nanopb version with the
+formula:
+`minor * 100,000 + patch * 100 + fourth`
+
+The CocoaPod major version will be 1 for the forseeable future. It is not
+0 because some CocoaPods incorrectly published with floating dependencies
+allowing updates to any 0 major version.
+
+The CocoaPods patch version should be used for any podspec or other packaging
+updates.
+
+#### Additional versioning background
 
 While nanopb tries to follow a variation of semver and updates the fourth digit
 for non-breaking patch updates, the policy is not enforced for binary
 dependencies which can break when source dependencies don't, like the `#define`
 changes in 0.3.9.4.
-
-The versioning scheme is exacerbated by early Firebase releases specifying
-CocoaPods dependencies with `"nanopb": "~> 0.3"` which allows an update to any
-subsequent 0.* release.

--- a/README.md
+++ b/README.md
@@ -2,10 +2,9 @@
 
 nanopb doesn't follow https://semver.org/, so we'll use the following scheme:
 
-nanopb version `a.b.c` becomes `a.b.(c*1000)` and nanopb version `a.b.c.d`
-becomes `a.b.(c*1000+d*10+podspec_revision)`
+Starting with nanopb 0.3.9.4, the CocoaPods version is disconnected from the
+nanopb version and is described by the following table:
 
-Example: nanopb 0.3.9 => 0.3.9000, and nanopb 0.3.9.1 => 0.3.9010
-
-Converted to four digit version after upgrade from 0.3.9.1 to 0.3.9.4 failed
-and required a rollback.
+| CocoaPods Version | nanopb version |
+| ----------------- | -------------- |
+| 1.0.0             | 0.3.9.4        |

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ breaking.
 
 The CocoaPods minor version is calculated from the nanopb version with the
 formula:
-`minor * 100,000 + patch * 100 + fourth`
+`minor * 10,000 + patch * 100 + fourth`
 
 The CocoaPod major version will be 1 for the forseeable future. It is not
 0 because some CocoaPods incorrectly published with floating dependencies

--- a/nanopb.podspec
+++ b/nanopb.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/nanopb/nanopb"
   s.license      = { :type => 'zlib', :file => 'LICENSE.txt' }
   s.author       = { "Petteri Aimonen" => "jpa@nanopb.mail.kapsi.fi" }
-  s.source       = { :git => "https://github.com/nanopb/nanopb.git", :tag => "0.3.9.4" }
+  s.source       = { :git => "https://github.com/nanopb/nanopb.git", :tag => "0.3.9.5" }
 
   s.requires_arc = false
   s.xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) PB_FIELD_32BIT=1 PB_NO_PACKED_STRUCTS=1 PB_ENABLE_MALLOC=1' }

--- a/nanopb.podspec
+++ b/nanopb.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = "nanopb"
   # CocoaPods minor version is minor * 100,000 + patch * 100 + fourth
-  s.version      = "1.300905.0"
+  s.version      = "1.30905.0"
   s.summary      = "Protocol buffers with small code size."
 
   s.description  = <<-DESC

--- a/nanopb.podspec
+++ b/nanopb.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "nanopb"
-  s.version      = "0.3.9011"
+  s.version      = "1.0.0"
   s.summary      = "Protocol buffers with small code size."
 
   s.description  = <<-DESC
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/nanopb/nanopb"
   s.license      = { :type => 'zlib', :file => 'LICENSE.txt' }
   s.author       = { "Petteri Aimonen" => "jpa@nanopb.mail.kapsi.fi" }
-  s.source       = { :git => "https://github.com/nanopb/nanopb.git", :tag => "0.3.9.1" }
+  s.source       = { :git => "https://github.com/nanopb/nanopb.git", :tag => "0.3.9.4" }
 
   s.requires_arc = false
   s.xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) PB_FIELD_32BIT=1 PB_NO_PACKED_STRUCTS=1 PB_ENABLE_MALLOC=1' }

--- a/nanopb.podspec
+++ b/nanopb.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "nanopb"
-  # CocoaPods minor version is minor * 100,000 + patch * 100 + fourth
+  # CocoaPods minor version is minor * 10,000 + patch * 100 + fourth
   s.version      = "1.30905.0"
   s.summary      = "Protocol buffers with small code size."
 

--- a/nanopb.podspec
+++ b/nanopb.podspec
@@ -1,6 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = "nanopb"
-  s.version      = "1.0.0"
+  # CocoaPods minor version is minor * 100,000 + patch * 100 + fourth
+  s.version      = "1.300905.0"
   s.summary      = "Protocol buffers with small code size."
 
   s.description  = <<-DESC


### PR DESCRIPTION
Updates to 0.3.9.5 and updates to a more sustainable versioning scheme.