### PR TITLE
updating from 0.3.9.5 to 0.3.9.6

### DIFF
--- a/nanopb.podspec
+++ b/nanopb.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = "nanopb"
   # CocoaPods minor version is minor * 10,000 + patch * 100 + fourth
-  s.version      = "1.30905.0"
+  s.version      = "1.30906.0"
   s.summary      = "Protocol buffers with small code size."
 
   s.description  = <<-DESC
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/nanopb/nanopb"
   s.license      = { :type => 'zlib', :file => 'LICENSE.txt' }
   s.author       = { "Petteri Aimonen" => "jpa@nanopb.mail.kapsi.fi" }
-  s.source       = { :git => "https://github.com/nanopb/nanopb.git", :tag => "0.3.9.5" }
+  s.source       = { :git => "https://github.com/nanopb/nanopb.git", :tag => "0.3.9.6" }
 
   s.requires_arc = false
   s.xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) PB_FIELD_32BIT=1 PB_NO_PACKED_STRUCTS=1 PB_ENABLE_MALLOC=1' }


### PR DESCRIPTION
This fixes build errors when using Python 3 (observed when building firebase cpp sdk, specifically firestore).