### PR TITLE
Bump minimum iOS version to address Xcode 12 warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,13 @@ The CocoaPods minor version is calculated from the nanopb version with the
 formula:
 `minor * 10,000 + patch * 100 + fourth`
 
-The CocoaPod major version will be 1 for the forseeable future. It is not
-0 because some CocoaPods incorrectly published with floating dependencies
-allowing updates to any 0 major version.
+The CocoaPod major version is not 0 because some CocoaPods incorrectly published
+with floating dependencies allowing updates to any 0 major version. Other major
+version updates may be done because of iOS support versioning changes even
+if the underlying nanopb library is unimpacted. For example, the major update
+from 1 to 2 is done to bump the minimum supported iOS version to 9 because
+Xcode 12 no longer supports iOS 8 and generates build warnings for nanopb
+client apps.
 
 The CocoaPods patch version should be used for any podspec or other packaging
 updates.

--- a/nanopb.podspec
+++ b/nanopb.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = "nanopb"
   # CocoaPods minor version is minor * 10,000 + patch * 100 + fourth
-  s.version      = "1.30906.0"
+  s.version      = "2.30906.0"
   s.summary      = "Protocol buffers with small code size."
 
   s.description  = <<-DESC
@@ -14,6 +14,11 @@ Pod::Spec.new do |s|
   s.license      = { :type => 'zlib', :file => 'LICENSE.txt' }
   s.author       = { "Petteri Aimonen" => "jpa@nanopb.mail.kapsi.fi" }
   s.source       = { :git => "https://github.com/nanopb/nanopb.git", :tag => "0.3.9.6" }
+
+  s.ios.deployment_target = '9.0'
+  s.osx.deployment_target = '10.9'
+  s.tvos.deployment_target = '9.0'
+  s.watchos.deployment_target = '2.0'
 
   s.requires_arc = false
   s.xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) PB_FIELD_32BIT=1 PB_NO_PACKED_STRUCTS=1 PB_ENABLE_MALLOC=1' }


### PR DESCRIPTION
Xcode 12 generates build warnings for iOS versions less than 9. More context at CocoaPods/CocoaPods#9884.

Since iOS is now specified as a platform in the podspec, also specify the other Apple platforms.