### PR TITLE
Bump min mac os version: Xcode 15 cannot build 10.9 and 10.10

### DIFF
--- a/nanopb.podspec
+++ b/nanopb.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = "nanopb"
   # CocoaPods minor version is minor * 10,000 + patch * 100 + fourth
-  s.version      = "2.30909.0"
+  s.version      = "2.30909.1"
   s.summary      = "Protocol buffers with small code size."
 
   s.description  = <<-DESC
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/nanopb/nanopb.git", :tag => "0.3.9.9" }
 
   s.ios.deployment_target = '9.0'
-  s.osx.deployment_target = '10.9'
+  s.osx.deployment_target = '10.11'
   s.tvos.deployment_target = '9.0'
   s.watchos.deployment_target = '2.0'
 


### PR DESCRIPTION
Xcode 15 errors trying to build for 10.9 or 10.10. Since neither of these versions have been supported by Firebase or other nanopb podspec dependencies, it's safe to bump to 10.11, still below the current supported version of 10.13

```
    - NOTE  | [OSX] xcodebuild:  clang: error: SDK does not contain 'libarclite' at the path '/Applications/Xcode15.1-beta.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/arc/libarclite_macosx.a'; try increasing the minimum deployment target
```