### PR TITLE
Update to 2.30910.0 for privacy manifest support

### DIFF
--- a/nanopb.podspec
+++ b/nanopb.podspec
@@ -35,4 +35,8 @@ Pod::Spec.new do |s|
     d.public_header_files = ['pb.h', 'pb_decode.h', 'pb_common.h']
     d.source_files = ['pb.h', 'pb_common.h', 'pb_common.c', 'pb_decode.h', 'pb_decode.c']
   end
+
+  s.resource_bundles = {
+    "#{s.module_name}_Privacy" => 'spm_resources/PrivacyInfo.xcprivacy'
+  }
 end

--- a/nanopb.podspec
+++ b/nanopb.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = "nanopb"
   # CocoaPods minor version is minor * 10,000 + patch * 100 + fourth
-  s.version      = "2.30909.1"
+  s.version      = "2.30910.0"
   s.summary      = "Protocol buffers with small code size."
 
   s.description  = <<-DESC
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/nanopb/nanopb"
   s.license      = { :type => 'zlib', :file => 'LICENSE.txt' }
   s.author       = { "Petteri Aimonen" => "jpa@nanopb.mail.kapsi.fi" }
-  s.source       = { :git => "https://github.com/nanopb/nanopb.git", :tag => "0.3.9.9" }
+  s.source       = { :git => "https://github.com/nanopb/nanopb.git", :tag => "0.3.9.10" }
 
   s.ios.deployment_target = '9.0'
   s.osx.deployment_target = '10.11'


### PR DESCRIPTION
Update to 2.30910.0 for privacy manifest support

Initially published to SpecsStaging before publishing to trunk